### PR TITLE
Implement unified upload handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The applications will fail to start if this variable is missing.
 
 ## Running the app
 
-Launch the unified interface using the helper scripts at the repository root:
+Launch the unified interface using the helper scripts at the repository root. These scripts run `unified_app.py` which accepts documents, images and CAD files in one place:
 
 ```bash
 # Windows

--- a/mm_kb_builder/app.py
+++ b/mm_kb_builder/app.py
@@ -943,7 +943,7 @@ def create_structured_metadata(analysis_result, user_additions, filename):
         "cad_metadata": analysis_result.get('cad_metadata', {})
     }
 
-def save_unified_knowledge_item(image_id, analysis_result, user_additions, embedding, filename, image_base64=None):
+def save_unified_knowledge_item(image_id, analysis_result, user_additions, embedding, filename, image_base64=None, original_bytes=None):
     """★ 統一ナレッジアイテムとして保存（RAGシステム互換構造）"""
     try:
         search_chunk = create_comprehensive_search_chunk(analysis_result, user_additions)
@@ -968,6 +968,7 @@ def save_unified_knowledge_item(image_id, analysis_result, user_additions, embed
             embedding=embedding,
             metadata=full_metadata,
             original_filename=filename,
+            original_bytes=original_bytes,
             image_bytes=image_bytes,
         )
         file_link = paths.get("original_file_path", "")
@@ -1044,6 +1045,8 @@ with tab1:
                 status_text = st.empty()
                 
                 for i, uploaded_file in enumerate(uploaded_files):
+                    file_bytes = uploaded_file.getvalue()
+                    uploaded_file.seek(0)
                     status_text.text(f"処理中: {uploaded_file.name} ({i+1}/{len(uploaded_files)})")
                     
                     file_extension = uploaded_file.name.split('.')[-1].lower()
@@ -1078,7 +1081,8 @@ with tab1:
                             'analysis': analysis,
                             'cad_metadata': cad_metadata,
                             'user_additions': {},
-                            'is_finalized': False
+                            'is_finalized': False,
+                            'original_bytes': file_bytes,
                         }
                         
                         file_type_display = "CADファイル" if is_cad_file else "画像"
@@ -1292,7 +1296,8 @@ with tab2:
                                         current_user_additions,
                                         embedding,
                                         image_data['filename'],
-                                        image_data['image_base64']
+                                        image_data['image_base64'],
+                                        original_bytes=image_data.get('original_bytes')
                                     )
                                     
                                     if success:

--- a/run_app.bat
+++ b/run_app.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Launch the unified Streamlit interface
 cd /d "%~dp0"
-streamlit run knowledge_gpt_app/app.py
+streamlit run unified_app.py
 pause
 

--- a/run_app.sh
+++ b/run_app.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Launch the unified Streamlit interface
 cd "$(dirname "$0")" || exit 1
-streamlit run knowledge_gpt_app/app.py
+streamlit run unified_app.py
 read -n 1 -s -r -p "Press any key to exit..."
 echo
 

--- a/unified_app.py
+++ b/unified_app.py
@@ -1,0 +1,91 @@
+import streamlit as st
+import uuid
+import base64
+
+from knowledge_gpt_app.app import (
+    read_file,
+    semantic_chunking,
+    get_openai_client,
+)
+from mm_kb_builder.app import (
+    process_cad_file,
+    encode_image_to_base64,
+    analyze_image_with_gpt4o,
+    create_comprehensive_search_chunk,
+    get_embedding,
+    save_unified_knowledge_item,
+    SUPPORTED_IMAGE_TYPES,
+    SUPPORTED_CAD_TYPES,
+)
+
+st.title("Unified Knowledge Upload")
+
+kb_name = st.text_input("Knowledge Base Name", "unified_kb")
+
+all_types = [
+    'pdf', 'docx', 'xlsx', 'xls', 'txt'
+] + SUPPORTED_IMAGE_TYPES + SUPPORTED_CAD_TYPES
+uploaded_files = st.file_uploader(
+    "Upload Files",
+    type=all_types,
+    accept_multiple_files=True,
+)
+
+if uploaded_files and st.button("Process Files"):
+    client = get_openai_client()
+    if not client:
+        st.error("OpenAI client unavailable")
+    else:
+        for file in uploaded_files:
+            ext = file.name.split('.')[-1].lower()
+            bytes_data = file.getvalue()
+            file.seek(0)
+            if ext in ['pdf', 'docx', 'xlsx', 'xls', 'txt']:
+                text = read_file(file)
+                if text:
+                    semantic_chunking(
+                        text,
+                        15,
+                        'C',
+                        'auto',
+                        kb_name,
+                        client,
+                        original_filename=file.name,
+                        original_bytes=bytes_data,
+                    )
+                    st.success(f"Processed text file {file.name}")
+                else:
+                    st.error(f"Failed to read {file.name}")
+            elif ext in SUPPORTED_IMAGE_TYPES + SUPPORTED_CAD_TYPES:
+                if ext in SUPPORTED_CAD_TYPES:
+                    img_b64, cad_meta = process_cad_file(file, ext)
+                    if img_b64 is None:
+                        st.error(f"CAD processing failed: {cad_meta.get('error')}")
+                        continue
+                else:
+                    img_b64 = encode_image_to_base64(file)
+                    cad_meta = None
+                analysis = analyze_image_with_gpt4o(img_b64, file.name, cad_meta, client)
+                if "error" in analysis:
+                    st.error(f"Analysis failed for {file.name}: {analysis['error']}")
+                    continue
+                chunk = create_comprehensive_search_chunk(analysis, {})
+                embedding = get_embedding(chunk, client)
+                if embedding is None:
+                    st.error(f"Embedding failed for {file.name}")
+                    continue
+                success, _ = save_unified_knowledge_item(
+                    str(uuid.uuid4()),
+                    analysis,
+                    {},
+                    embedding,
+                    file.name,
+                    img_b64,
+                    original_bytes=bytes_data,
+                )
+                if success:
+                    st.success(f"Processed image/CAD file {file.name}")
+                else:
+                    st.error(f"Saving failed for {file.name}")
+            else:
+                st.warning(f"Unsupported file type: {file.name}")


### PR DESCRIPTION
## Summary
- add unified_app.py to process both document and image uploads
- capture original file bytes in mm_kb_builder and pass to save_unified_knowledge_item
- preserve originals during semantic chunking in knowledge_gpt_app
- point run_app scripts at the new unified interface
- document new workflow in README

## Testing
- `python -m py_compile unified_app.py knowledge_gpt_app/app.py mm_kb_builder/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846e97fa4b88333bb5232ed804fd128