### PR TITLE
Implement phase 3 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,10 @@ run_app.bat
 ## Integration Plan
 
 See [docs/integration_plan.md](docs/integration_plan.md) for an overview of the integration phases.
+
+### Phase 3 Notes
+
+Processed chunks, embeddings and metadata are now stored under
+`knowledge_base/<kb_name>` using `save_processed_data()`. The metadata JSON
+includes these paths so that other components can access the original files.
+Whenever a chunk is stored the chatbot search index is refreshed automatically.

--- a/docs/integration_plan.md
+++ b/docs/integration_plan.md
@@ -23,6 +23,13 @@ This document outlines the major phases for integrating the knowledge base build
   - Maintain links between original files and processed data.
   - Update indexing so that the chatbot can access new entries.
 
+### Phase 3 Implementation
+
+`save_processed_data()` now writes files under `knowledge_base/<kb_name>` and
+returns their paths. These paths are stored inside each chunk's metadata JSON so
+that the chatbot can provide download links. When a chunk or image is saved the
+corresponding search index is refreshed via `refresh_search_engine()`.
+
 ## FAQ Generation
 - **Objective:** Automatically create frequently asked questions from the knowledge base.
 - **Key tasks:**

--- a/knowledge_gpt_app/app.py
+++ b/knowledge_gpt_app/app.py
@@ -778,6 +778,15 @@ def get_search_engine(kb_name: str) -> HybridSearchEngine:
             return None
     return st.session_state.search_engines[kb_name]
 
+def refresh_search_engine(kb_name: str) -> None:
+    """Rebuild indexes for a knowledge base if a search engine is available."""
+    engine = get_search_engine(kb_name)
+    if engine is not None:
+        try:
+            engine.reindex()
+        except Exception as e:
+            logger.error(f"Failed to refresh index for '{kb_name}': {e}", exc_info=True)
+
 def list_knowledge_bases():
     kb_list = []
     if RAG_BASE_DIR.exists():
@@ -1051,6 +1060,7 @@ def save_chunk_to_files(chunk_content, chunk_id, folder_name, base_filename, met
             embedding=embedding,
             metadata=metadata,
         )
+        refresh_search_engine(kb_dir_path.name)
         return [
             paths.get("chunk_path"),
             paths.get("metadata_path"),

--- a/knowledge_gpt_app/knowledge_search.py
+++ b/knowledge_gpt_app/knowledge_search.py
@@ -135,6 +135,13 @@ class HybridSearchEngine:
             print(f"SentenceTransformer 読み込みエラー: {e_st}")
             self.model = None
 
+    def reindex(self) -> None:
+        """Reload all chunks and embeddings and rebuild the BM25 index."""
+        self.chunks = self._load_chunks()
+        self.embeddings = self._load_embeddings()
+        self._check_chunk_embedding_consistency()
+        self.bm25_index = self._load_or_build_bm25_index()
+
     def _load_kb_metadata(self) -> dict:
         metadata_file = self.kb_path / "kb_metadata.json"
         if metadata_file.exists():

--- a/mm_kb_builder/app.py
+++ b/mm_kb_builder/app.py
@@ -18,6 +18,7 @@ from shared.upload_utils import (
     BASE_KNOWLEDGE_DIR as SHARED_KB_DIR,
     ensure_openai_key,
 )
+from knowledge_gpt_app.app import refresh_search_engine
 
 # ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
 # インテル風デザインテーマ適用
@@ -971,6 +972,7 @@ def save_unified_knowledge_item(image_id, analysis_result, user_additions, embed
             original_bytes=original_bytes,
             image_bytes=image_bytes,
         )
+        refresh_search_engine(kb_name)
         file_link = paths.get("original_file_path", "")
 
         return True, {

--- a/shared/upload_utils.py
+++ b/shared/upload_utils.py
@@ -2,6 +2,7 @@ import os
 import json
 import pickle
 from pathlib import Path
+from typing import Dict, Any
 
 # Base directory for all knowledge bases
 BASE_KNOWLEDGE_DIR = Path(__file__).resolve().parent.parent / "knowledge_base"
@@ -36,26 +37,21 @@ def save_processed_data(
     original_bytes: bytes = None,
     image_bytes: bytes = None,
 ):
-    """Save processed chunk, embedding and metadata in a unified layout."""
+    """Save processed chunk, embedding and metadata in a unified layout.
+
+    Returned paths are also embedded inside the saved metadata so that other
+    components can easily reference stored files.
+    """
     kb_dir = BASE_KNOWLEDGE_DIR / kb_name
     dirs = _ensure_dirs(kb_dir)
 
-    paths = {}
+    paths: Dict[str, Any] = {}
 
     if chunk_text is not None:
         chunk_path = dirs["chunks"] / f"{chunk_id}.txt"
         with open(chunk_path, "w", encoding="utf-8") as f:
             f.write(chunk_text)
         paths["chunk_path"] = str(chunk_path)
-
-    if metadata is not None:
-        meta = metadata.copy()
-        if original_filename:
-            meta.setdefault("original_file", original_filename)
-        meta_path = dirs["metadata"] / f"{chunk_id}.json"
-        with open(meta_path, "w", encoding="utf-8") as f:
-            json.dump(meta, f, ensure_ascii=False, indent=2)
-        paths["metadata_path"] = str(meta_path)
 
     if embedding is not None:
         emb_path = dirs["embeddings"] / f"{chunk_id}.pkl"
@@ -71,8 +67,31 @@ def save_processed_data(
 
     if original_bytes is not None and original_filename:
         file_path = dirs["files"] / original_filename
+        if file_path.exists():
+            existing_bytes = file_path.read_bytes()
+            if existing_bytes != original_bytes:
+                base = file_path.stem
+                ext = file_path.suffix
+                version = 1
+                while True:
+                    new_name = f"{base}_v{version}{ext}"
+                    new_path = file_path.with_name(new_name)
+                    if not new_path.exists():
+                        file_path = new_path
+                        break
+                    version += 1
         with open(file_path, "wb") as f:
             f.write(original_bytes)
         paths["original_file_path"] = str(file_path)
+
+    if metadata is not None:
+        meta = metadata.copy()
+        if original_filename:
+            meta.setdefault("original_file", original_filename)
+        meta["paths"] = paths
+        meta_path = dirs["metadata"] / f"{chunk_id}.json"
+        with open(meta_path, "w", encoding="utf-8") as f:
+            json.dump(meta, f, ensure_ascii=False, indent=2)
+        paths["metadata_path"] = str(meta_path)
 
     return paths

--- a/tests/test_upload_utils.py
+++ b/tests/test_upload_utils.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from shared import upload_utils
+
+
+def test_save_processed_data_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(upload_utils, "BASE_KNOWLEDGE_DIR", tmp_path)
+    paths = upload_utils.save_processed_data(
+        "kb",
+        "1",
+        chunk_text="hello",
+        embedding=[0.1, 0.2],
+        metadata={"foo": "bar"},
+        original_filename="orig.txt",
+        original_bytes=b"data",
+        image_bytes=b"img",
+    )
+    meta = json.loads(Path(paths["metadata_path"]).read_text(encoding="utf-8"))
+    assert meta["paths"]["chunk_path"] == paths["chunk_path"]
+    assert "original_file_path" in meta["paths"]
+
+
+def test_save_processed_data_version(tmp_path, monkeypatch):
+    monkeypatch.setattr(upload_utils, "BASE_KNOWLEDGE_DIR", tmp_path)
+    first = upload_utils.save_processed_data(
+        "kb",
+        "1",
+        metadata={},
+        original_filename="file.txt",
+        original_bytes=b"a",
+    )
+    second = upload_utils.save_processed_data(
+        "kb",
+        "2",
+        metadata={},
+        original_filename="file.txt",
+        original_bytes=b"a",
+    )
+    assert Path(first["original_file_path"]) == Path(second["original_file_path"])
+    third = upload_utils.save_processed_data(
+        "kb",
+        "3",
+        metadata={},
+        original_filename="file.txt",
+        original_bytes=b"b",
+    )
+    assert Path(third["original_file_path"]) != Path(first["original_file_path"])


### PR DESCRIPTION
## Summary
- reorganize `save_processed_data` to record stored file paths and handle duplicate uploads
- refresh search index after saving knowledge items
- document phase 3 behavior in README and integration plan
- add unit tests for the updated storage logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847601dc1c48333a15be94a0234adb8