### PR TITLE
Add manual reindex tool and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,13 @@ Processed chunks, embeddings and metadata are now stored under
 `knowledge_base/<kb_name>` using `save_processed_data()`. The metadata JSON
 includes these paths so that other components can access the original files.
 Whenever a chunk is stored the chatbot search index is refreshed automatically.
+
+If you upload a file with the same name but different content, a version
+number is appended so the existing file is preserved. To rebuild the search
+index for an existing knowledge base you can run:
+
+```bash
+python reindex_kb.py <kb_name>
+```
+
+This reloads all chunks from disk and regenerates the BM25 index.

--- a/docs/integration_plan.md
+++ b/docs/integration_plan.md
@@ -30,6 +30,14 @@ returns their paths. These paths are stored inside each chunk's metadata JSON so
 that the chatbot can provide download links. When a chunk or image is saved the
 corresponding search index is refreshed via `refresh_search_engine()`.
 
+If a file with the same name already exists, the new one will be saved with a
+version suffix so older uploads remain intact. A standalone `reindex_kb.py`
+script is provided to rebuild indexes from disk:
+
+```bash
+python reindex_kb.py <kb_name>
+```
+
 ## FAQ Generation
 - **Objective:** Automatically create frequently asked questions from the knowledge base.
 - **Key tasks:**

--- a/reindex_kb.py
+++ b/reindex_kb.py
@@ -1,0 +1,26 @@
+import argparse
+from pathlib import Path
+from knowledge_gpt_app.knowledge_search import HybridSearchEngine
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Rebuild indexes for an existing knowledge base"
+    )
+    parser.add_argument(
+        "kb_name",
+        help="Name of the knowledge base directory under knowledge_base/",
+    )
+    args = parser.parse_args()
+
+    kb_path = Path("knowledge_base") / args.kb_name
+    if not kb_path.exists():
+        parser.error(f"Knowledge base '{args.kb_name}' not found at {kb_path}")
+
+    engine = HybridSearchEngine(str(kb_path))
+    engine.reindex()
+    print(f"Reindex complete for '{args.kb_name}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_reindex.py
+++ b/tests/test_reindex.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from shared import upload_utils
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("rank_bm25")
+pytest.importorskip("sentence_transformers")
+pytest.importorskip("nltk")
+from knowledge_gpt_app.knowledge_search import HybridSearchEngine
+
+
+def test_reindex_loads_new_chunks(tmp_path, monkeypatch):
+    monkeypatch.setattr(upload_utils, "BASE_KNOWLEDGE_DIR", tmp_path)
+    kb_name = "kb"
+    # save two chunks
+    upload_utils.save_processed_data(kb_name, "1", chunk_text="a", embedding=[1], metadata={})
+    upload_utils.save_processed_data(kb_name, "2", chunk_text="b", embedding=[2], metadata={})
+    engine = HybridSearchEngine(str(tmp_path / kb_name))
+    assert len(engine.chunks) == 2
+
+    # save another chunk after engine initialization
+    upload_utils.save_processed_data(kb_name, "3", chunk_text="c", embedding=[3], metadata={})
+    assert len(engine.chunks) == 2  # engine not aware yet
+
+    engine.reindex()
+    assert len(engine.chunks) == 3
+


### PR DESCRIPTION
## Summary
- add `reindex_kb.py` helper for rebuilding indexes manually
- document duplicate file versioning and reindex steps
- test manual reindex with `HybridSearchEngine`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847767d71d08333a1bd5c17aeaaad66