### PR TITLE
Implement FAQ generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,11 @@ python reindex_kb.py <kb_name>
 ```
 
 This reloads all chunks from disk and regenerates the BM25 index.
+
+To automatically create FAQs from existing chunks run:
+
+```bash
+python generate_faq.py <kb_name>
+```
+
+Generated files are placed under `knowledge_base/<kb_name>/faq/` and can be viewed from the chat sidebar.

--- a/docs/integration_plan.md
+++ b/docs/integration_plan.md
@@ -45,6 +45,10 @@ python reindex_kb.py <kb_name>
   - Generate question and answer pairs with GPT.
   - Store generated FAQs for reference within the app.
 
+### Phase 4 Implementation
+
+The `generate_faq.py` script reads all chunk text under `knowledge_base/<kb_name>/chunks` and uses GPT to create a single Q&A pair for each chunk. The results are saved as individual JSON files under `knowledge_base/<kb_name>/faq/` with metadata describing the source chunk and generation time. The chatbot UI loads these files so users can browse or search FAQs from the sidebar.
+
 ## Local Storage
 - **Objective:** Keep all data on disk so that the app can run offline.
 - **Key tasks:**

--- a/generate_faq.py
+++ b/generate_faq.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+"""CLI to generate FAQ files from an existing knowledge base."""
+import sys
+from shared import faq_utils
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python generate_faq.py <kb_name>")
+        sys.exit(1)
+    kb_name = sys.argv[1]
+    created = faq_utils.generate_faqs_from_chunks(kb_name)
+    print(f"Generated {len(created)} FAQ files in knowledge_base/{kb_name}/faq")
+
+
+if __name__ == "__main__":
+    main()

--- a/knowledge_gpt_app/app.py
+++ b/knowledge_gpt_app/app.py
@@ -1479,6 +1479,18 @@ elif app_mode == "ナレッジ検索":
             st.sidebar.caption(f"準備済エンジン: {', '.join(loaded_engine_names)}")
         else:
             st.sidebar.caption("検索エンジンは検索実行時に自動準備されます。")
+
+        if selected_kb_display_option_ui != all_kb_option_display_ui:
+            from shared.faq_utils import load_faqs
+            faqs_for_sidebar = load_faqs(selected_kb_display_option_ui)
+            if faqs_for_sidebar:
+                with st.sidebar.expander("FAQ一覧", expanded=False):
+                    query = st.text_input("FAQ検索", key="faq_search")
+                    for faq_item in faqs_for_sidebar:
+                        if not query or query in faq_item.get("question", ""):
+                            st.markdown(f"**Q:** {faq_item.get('question','')}\n\n{faq_item.get('answer','')}")
+            else:
+                st.sidebar.caption("FAQがありません。")
     else:
         st.sidebar.warning("利用可能なナレッジベースがありません。「ナレッジベース管理」モードでナレッジベースを作成してください。")
     st.sidebar.header("検索パラメータ")

--- a/shared/faq_utils.py
+++ b/shared/faq_utils.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+import json
+from typing import List, Dict, Any, Optional
+from datetime import datetime
+import uuid
+from openai import OpenAI
+
+from .upload_utils import BASE_KNOWLEDGE_DIR, ensure_openai_key
+
+
+def _load_chunks(kb_name: str) -> Dict[str, str]:
+    """Return mapping of chunk_id -> text for a knowledge base."""
+    chunk_dir = BASE_KNOWLEDGE_DIR / kb_name / "chunks"
+    texts: Dict[str, str] = {}
+    if chunk_dir.exists():
+        for p in chunk_dir.glob("*.txt"):
+            texts[p.stem] = p.read_text(encoding="utf-8")
+    return texts
+
+
+def _generate_single_faq(client: OpenAI, text: str) -> Dict[str, str]:
+    """Call GPT to generate a single Q&A pair from text."""
+    system = "あなたはFAQ作成アシスタントです。JSON形式で1つの質問と回答を生成してください。"
+    user = f"以下のテキストからよくある質問を1つ想定し、回答を作成してください。JSON形式で返してください。\n{text}"
+    resp = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "system", "content": system}, {"role": "user", "content": user}],
+        max_tokens=300,
+    )
+    try:
+        data = json.loads(resp.choices[0].message.content)
+        return {"question": data.get("question", ""), "answer": data.get("answer", "")}
+    except Exception:
+        return {"question": "", "answer": ""}
+
+
+def generate_faqs_from_chunks(kb_name: str, *, client: Optional[OpenAI] = None) -> List[str]:
+    """Generate FAQ files from existing chunks.
+
+    Returns list of created file paths.
+    """
+    if client is None:
+        key = ensure_openai_key()
+        client = OpenAI(api_key=key)
+
+    chunks = _load_chunks(kb_name)
+    faq_dir = BASE_KNOWLEDGE_DIR / kb_name / "faq"
+    faq_dir.mkdir(parents=True, exist_ok=True)
+    created: List[str] = []
+
+    for cid, text in chunks.items():
+        faq = _generate_single_faq(client, text)
+        faq_data = {
+            "question": faq.get("question", ""),
+            "answer": faq.get("answer", ""),
+            "generated_at": datetime.now().isoformat(),
+            "source_chunk": cid,
+        }
+        path = faq_dir / f"faq_{uuid.uuid4().hex}.json"
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(faq_data, f, ensure_ascii=False, indent=2)
+        created.append(str(path))
+
+    return created
+
+
+def load_faqs(kb_name: str) -> List[Dict[str, Any]]:
+    """Load all FAQ JSON objects for a knowledge base."""
+    faq_dir = BASE_KNOWLEDGE_DIR / kb_name / "faq"
+    faqs = []
+    if faq_dir.exists():
+        for p in sorted(faq_dir.glob("*.json")):
+            try:
+                with open(p, "r", encoding="utf-8") as f:
+                    faqs.append(json.load(f))
+            except Exception:
+                continue
+    return faqs

--- a/tests/test_faq_utils.py
+++ b/tests/test_faq_utils.py
@@ -1,0 +1,68 @@
+
+import json
+from pathlib import Path
+import sys
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide stub for openai so faq_utils can be imported without the real package
+sys.modules['openai'] = types.SimpleNamespace(OpenAI=lambda **_: None)
+
+from shared import faq_utils
+
+
+class DummyClient:
+    def __init__(self, content):
+        self._content = content
+        self.chat = self.Chat(self)
+
+    class Chat:
+        def __init__(self, outer):
+            self.completions = outer.Completions(outer)
+
+    class Completions:
+        def __init__(self, outer):
+            self._content = outer._content
+
+        def create(self, *args, **kwargs):
+            return type(
+                "Resp",
+                (),
+                {
+                    "choices": [
+                        type("Choice", (), {"message": type("Msg", (), {"content": self._content})()})
+                    ]
+                },
+            )()
+
+
+def test_generate_faqs_creates_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(faq_utils, "BASE_KNOWLEDGE_DIR", tmp_path)
+    kb_dir = tmp_path / "kb"
+    chunk_dir = kb_dir / "chunks"
+    chunk_dir.mkdir(parents=True)
+    (chunk_dir / "1.txt").write_text("hello", encoding="utf-8")
+
+    client = DummyClient('{"question": "Q1", "answer": "A1"}')
+    paths = faq_utils.generate_faqs_from_chunks("kb", client=client)
+
+    assert len(paths) == 1
+    data = json.loads(Path(paths[0]).read_text(encoding="utf-8"))
+    assert data["question"] == "Q1"
+    assert data["answer"] == "A1"
+    assert data["source_chunk"] == "1"
+
+
+def test_generate_faqs_separate_kb(tmp_path, monkeypatch):
+    monkeypatch.setattr(faq_utils, "BASE_KNOWLEDGE_DIR", tmp_path)
+    for name in ["kb1", "kb2"]:
+        d = tmp_path / name / "chunks"
+        d.mkdir(parents=True)
+        (d / "x.txt").write_text("text", encoding="utf-8")
+    client = DummyClient('{"question": "Q", "answer": "A"}')
+    faq_utils.generate_faqs_from_chunks("kb1", client=client)
+    faq_utils.generate_faqs_from_chunks("kb2", client=client)
+    assert (tmp_path / "kb1" / "faq").exists()
+    assert (tmp_path / "kb2" / "faq").exists()
+


### PR DESCRIPTION
## Summary
- add `faq_utils` helper with GPT-based FAQ generation
- expose `generate_faq.py` CLI
- show generated FAQs in the chat sidebar
- document FAQ workflow in README and integration plan
- test FAQ utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68477dbc7a54833398ac44fff53d9a28