### PR TITLE
Fix mm_kb_builder import

### DIFF
--- a/knowledge_gpt_app/app.py
+++ b/knowledge_gpt_app/app.py
@@ -357,6 +357,11 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 os.chdir(current_dir)
 print(f"カレントディレクトリを設定: {current_dir}")
 
+# 親ディレクトリ(リポジトリルート)をパスに追加
+repo_root = os.path.dirname(current_dir)
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+
 # 強化版NLTKリソースダウンロード関数
 def ensure_nltk_resources():
     """必要なNLTKリソースが確実にダウンロードされるようにする"""

--- a/mm_kb_builder/app.py
+++ b/mm_kb_builder/app.py
@@ -438,6 +438,11 @@ except ImportError:
 current_dir = os.path.dirname(os.path.abspath(__file__))
 os.chdir(current_dir)
 
+# 親ディレクトリ(リポジトリルート)をパスに追加
+repo_root = os.path.dirname(current_dir)
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+
 # ロギング設定
 logging.basicConfig(
     level=logging.INFO,


### PR DESCRIPTION
## Summary
- keep repo root in `sys.path` after modules change the working directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c45c508483338db901bd4e42b9d5