### PR TITLE
Fix page config conflict

### DIFF
--- a/knowledge_gpt_app/app.py
+++ b/knowledge_gpt_app/app.py
@@ -561,6 +561,7 @@ if 'response_length' not in st.session_state:
 
 # Streamlit UIの設定
 st.set_page_config(page_title="RAGシステム統合ツール", layout="wide")
+st.session_state["_page_configured"] = True
 
 # カスタムCSSを適用
 apply_intel_theme()

--- a/mm_kb_builder/app.py
+++ b/mm_kb_builder/app.py
@@ -368,10 +368,12 @@ def apply_intel_theme():
 # ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
 # ページ設定
 # ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
-st.set_page_config(
-    page_title="マルチモーダルナレッジ構築ツール",
-    layout="wide"
-)
+if not st.session_state.get("_page_configured", False):
+    st.set_page_config(
+        page_title="マルチモーダルナレッジ構築ツール",
+        layout="wide",
+    )
+    st.session_state["_page_configured"] = True
 
 # インテル風テーマ適用
 apply_intel_theme()

--- a/unified_app.py
+++ b/unified_app.py
@@ -2,6 +2,8 @@ import streamlit as st
 import uuid
 import base64
 
+st.set_page_config(page_title="Unified Knowledge Upload", layout="wide")
+
 from knowledge_gpt_app.app import (
     read_file,
     semantic_chunking,


### PR DESCRIPTION
## Summary
- prevent multiple `set_page_config` calls by using `_page_configured` flag
- configure the unified app page directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847cab72ea483338496b217a6695906