### PR TITLE
Fix page config duplication across modules

### DIFF
--- a/knowledge_gpt_app/app.py
+++ b/knowledge_gpt_app/app.py
@@ -560,8 +560,9 @@ if 'response_length' not in st.session_state:
     st.session_state['response_length'] = "普通"
 
 # Streamlit UIの設定
-st.set_page_config(page_title="RAGシステム統合ツール", layout="wide")
-st.session_state["_page_configured"] = True
+if "_page_configured" not in st.session_state:
+    st.set_page_config(page_title="RAGシステム統合ツール", layout="wide")
+    st.session_state["_page_configured"] = True
 
 # カスタムCSSを適用
 apply_intel_theme()

--- a/unified_app.py
+++ b/unified_app.py
@@ -2,7 +2,10 @@ import streamlit as st
 import uuid
 import base64
 
-st.set_page_config(page_title="Unified Knowledge Upload", layout="wide")
+# Ensure Streamlit page configuration is applied once across modules
+if "_page_configured" not in st.session_state:
+    st.set_page_config(page_title="Unified Knowledge Upload", layout="wide")
+    st.session_state["_page_configured"] = True
 
 from knowledge_gpt_app.app import (
     read_file,


### PR DESCRIPTION
## Summary
- ensure Streamlit page config is set only once
- guard against duplicate `st.set_page_config` calls in `unified_app` and `knowledge_gpt_app`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847cddca6c48333abf79a7c1dceebd5