### PR TITLE
Fix missing sys import

### DIFF
--- a/mm_kb_builder/app.py
+++ b/mm_kb_builder/app.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import streamlit as st
 from openai import OpenAI
 import json


### PR DESCRIPTION
## Summary
- add `sys` import in `mm_kb_builder/app.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d409f2208333bc6b7b8399201dee