### PR TITLE
Fix unified app path for backward compatibility

### DIFF
--- a/mm_kb_builder/unified_app.py
+++ b/mm_kb_builder/unified_app.py
@@ -1,0 +1,10 @@
+import runpy
+import sys
+from pathlib import Path
+
+# Allow imports from repository root
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+# Execute the unified app located at the repository root
+runpy.run_path(str(ROOT_DIR / "unified_app.py"), run_name="__main__")


### PR DESCRIPTION
## Summary
- add wrapper `mm_kb_builder/unified_app.py` so any old references run the actual unified interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847de883a8083338dff70efe57f8aa3