### PR TITLE
Document IPAexGothic font usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ export OPENAI_API_KEY=your_api_key_here
 
 The applications will fail to start if this variable is missing.
 
+## IPAexGothic font
+
+`knowledge_gpt_app/utils/export.py` generates PDF files and requires the
+`ipaexg.ttf` font to render Japanese text.  Download the IPAexGothic font from
+<https://moji.or.jp/ipafont/> and place the `ipaexg.ttf` file in the repository
+root so that PDF export works correctly.
+
 ## Running the app
 
 Launch the unified interface using the helper scripts at the repository root. These scripts run `unified_app.py` which accepts documents, images and CAD files in one place:

--- a/knowledge_gpt_app/utils/export.py
+++ b/knowledge_gpt_app/utils/export.py
@@ -45,9 +45,14 @@ def export_conversation_to_pdf(conversation_id, messages):
     # PDFの作成
     pdf = FPDF()
     pdf.add_page()
-    
+
     # フォント設定
-    pdf.add_font('IPAGothic', '', 'ipaexg.ttf', uni=True)
+    font_path = Path("ipaexg.ttf")
+    if not font_path.exists():
+        raise FileNotFoundError(
+            "ipaexg.ttf not found. Download IPAexGothic from https://moji.or.jp/ipafont/ and place it in the repository root."
+        )
+    pdf.add_font('IPAGothic', '', str(font_path), uni=True)
     pdf.set_font('IPAGothic', '', 10)
     
     # タイトル


### PR DESCRIPTION
## Summary
- document that export.py depends on ipaexg.ttf
- explain how to obtain IPAexGothic and where to place it
- raise a helpful error in export.py when the font is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cabdb8a40833388f936ffbb568fa5